### PR TITLE
Vendorkeys

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -33,6 +33,13 @@
 /* Shell command helper - DO NOT EDIT */
 #define SHCMD(cmd) {.com = (const char*[]){"/bin/sh", "-c", cmd, NULL}}
 
+/* Define commands to run on volume/brightness keypress events */
+static const char *brightnessup[] = { "xbacklight", "-inc", "5",     NULL };
+static const char *brightnessdown[] = { "xbacklight", "-dec", "5",     NULL };
+static const char *voldown[] = { "amixer", "-q", "set", "Master", "5-",     NULL };
+static const char *volup[] = { "amixer", "-q", "set", "Master", "5+",     NULL };
+static const char *volmute[] = { "amixer", "-q", "set", "Master", "toggle",     NULL };
+
 /* Shell commands */
 static const char *termcmd[] = { "xterm",     NULL };
 static const char *menucmd[] = { "rofi","-show","run", NULL };
@@ -68,6 +75,13 @@ static key keys[] = {
     {  MOD4,             XK_d,          spawn,             {.com = menucmd}},
     /* quit current window */
     {  MOD4,             XK_q,          killclient,        {NULL}},
+    
+     {  0, XF86XK_MonBrightnessUp,   spawn,             {.com = brightnessup}}, 
+     {  0, XF86XK_MonBrightnessDown, spawn,             {.com = brightnessdown}},      
+     {  0, XF86XK_AudioLowerVolume,  spawn,             {.com = voldown}},     
+     {  0, XF86XK_AudioRaiseVolume,  spawn,             {.com = volup}}, 
+     {  0, XF86XK_AudioMute,  		 spawn,             {.com = volmute}}, 
+          
     /* desktop selection */
        DESKTOPCHANGE(    XK_1,                             0)
        DESKTOPCHANGE(    XK_2,                             1)

--- a/examples/akita_mmwm
+++ b/examples/akita_mmwm
@@ -253,10 +253,10 @@ while read -r line ; do
 		button/mute*)
 			VOL=$( amixer sget Master | awk -F ' ' 'NR == 5 {print substr($4, 2, 3)}' )
 			if [[ $(amixer sget Master | grep "\[on\]") ]]; then
-				echo "V $ICON $VOLMUTE" > "$PANEL_FIFO"
+				echo "V $ICON $VOLON %{B$colourvol}%{F#1d1e20} $VOL"
 			else
-				echo "V $ICON $VOLON %{B$colourvol}%{F#1d1e20} $VOL" > "$PANEL_FIFO"
-			fi
+				echo "V $ICON $VOLMUTE"
+			fi > "$PANEL_FIFO"
 			;;
 		button/volume*)
 			VOL=$( amixer sget Master | awk -F ' ' 'NR == 5 {print substr($4, 2, 3)}' )

--- a/examples/bruno_mmwm
+++ b/examples/bruno_mmwm
@@ -239,7 +239,7 @@ while read -r line ; do
 			;;
 		button/mute*)
 			VOL=$( amixer sget Master | awk -F ' ' 'NR == 5 {print substr($4, 2, 3)}' )
-			if [[ $(amixer sget Master | grep "\[on\]") ]]; then
+			if [[ ! $(amixer sget Master | grep "\[on\]") ]]; then
 				echo "V $ICON $VOLMUTE" 
 			elif [ "$VOL" -gt 74 ] ; then
 				echo "V$VOL3"

--- a/mmwm.c
+++ b/mmwm.c
@@ -9,6 +9,7 @@
 #include <regex.h>
 #include <sys/wait.h>
 #include <X11/keysym.h>
+#include <X11/XF86keysym.h>
 #include <xcb/xcb.h>
 #include <xcb/xcb_atom.h>
 #include <xcb/xcb_aux.h>


### PR DESCRIPTION
I don't know if leaving out support for vendor keys is part of the project's goal to stay minimal but I found their absence conspicuous since most other wm's support them. FrankenWM also does not support these keys so it doesn't seem like they were intentionally omitted. It's possible to workaround this issue with the current build by manually defining the keycodes with the output of xev or the like, but I think the average user would be confused why their build failed to compile when defining vendor keys. I added the relevant library to mmwm.c and examples of how they would be used in config.def.h. If you want to keep the default config as clean as possible then feel free to reject the changes to the config or ask me to make a pull request with the changes as an optional patch.